### PR TITLE
Update frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@ FROM jinaai/jina:3.7.14-standard
 COPY . /workspace
 WORKDIR /workspace
 
+RUN apt-get update && apt-get install --no-install-recommends -y git build-essential g++
 RUN pip install streamlit==1.12.0
 
 EXPOSE 8509


### PR DESCRIPTION
Installing the dependencies is required otherwise it would fail to compile and install streamlit.